### PR TITLE
Restore manual toc placement

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1,9 +1,7 @@
-
-
 = HerdCache
+:toc: macro
 
-:toc:
-
+toc::[]
 
 = Overview
 


### PR DESCRIPTION
This patch restores manual toc placement now that GitHub is running Asciidoctor 1.5.2.