### PR TITLE
Switched PortUtil to use getLoopbackAddress

### DIFF
--- a/src/test/java/org/greencheek/caching/herdcache/memcached/util/PortUtil.java
+++ b/src/test/java/org/greencheek/caching/herdcache/memcached/util/PortUtil.java
@@ -11,7 +11,7 @@ public class PortUtil {
     public static ServerSocket findFreePort() {
         ServerSocket server = null;
         try {
-            server = new ServerSocket(0,1000, InetAddress.getLocalHost());
+            server = new ServerSocket(0,1000, InetAddress.getLoopbackAddress());
             server.setReuseAddress(true);
         } catch (IOException e) {
             e.printStackTrace();


### PR DESCRIPTION
We reuse the MemcachedDaemonFactory within our application tests.
However, when run from our corporate network the PortUtil fails to
bind to any addresses because of the VPN being used.

Under the hood the VPN doesn't resole InetAddress.getLocalHost() to
the address of your local machine and hence fails to bind ports.

I've updated it to using InetAddress.getLoopbackAddress() to overcome
this.